### PR TITLE
Allow "main" as a deployable branch

### DIFF
--- a/carpetbag.py
+++ b/carpetbag.py
@@ -26,7 +26,8 @@ def deployable_token(tokens):
 
 def deployable_job(u):
     return ((u.status == 'build succeeded') and
-            (u.reference == 'refs/heads/master') and
+            ((u.reference == 'refs/heads/master') or
+             (u.reference == 'refs/heads/main')) and
             (u.package != 'playground'))
 
 


### PR DESCRIPTION
Git repositories, including newlib-cygwin, are increasingly using "main" rather than "master" as the default branch name.  As such, Scallywag should treat the two equivalently, rather than only allowing deployment from a branch called "master".